### PR TITLE
Add category endpoint

### DIFF
--- a/src/uynab/model/budget.py
+++ b/src/uynab/model/budget.py
@@ -1,24 +1,66 @@
+"""
+# Model budget module.
+
+This module defines the models related to budgets in the application using Pydantic BaseModel.
+
+Classes:
+    Budget: Represents a budget with various attributes such as accounts, payees, categories, and transactions.
+    ResponseDataBudget: Represents the response data for a single budget.
+    ResponseBudget: Represents the response structure for a single budget.
+    ResponseDataBudgets: Represents the response data for multiple budgets.
+    ResponseBudgets: Represents the response structure for multiple budgets.
+    BudgetSettings: Represents the settings for a budget, including date and currency formats.
+    ResponseDataBudgetSettings: Represents the response data for budget settings.
+    ResponseBudgetSettings: Represents the response structure for budget settings.
+"""
+
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel
 
+from .category import Category, CategoryGroup
 from .payee import Payee
+from .utils import Account, CurrencyFormat, DateFormat, Month
 
 
 class Budget(BaseModel):
+    """
+    A class representing a budget in the application.
+
+    Attributes:
+        id (UUID): The unique identifier of the budget.
+        name (str): The name of the budget.
+        last_modified_on (datetime): The date and time when the budget was last modified.
+        first_month (datetime): The first month of the budget.
+        last_month (datetime): The last month of the budget.
+        date_format (DateFormat): The date format used in the budget.
+        currency_format (CurrencyFormat): The currency format used in the budget.
+        accounts (list[Account]): A list of accounts associated with the budget.
+        payees (list[Payee]): A list of payees associated with the budget.
+        payee_locations (list[dict]): A list of payee locations associated with the budget.
+        category_groups (list[CategoryGroup]): A list of category groups in the budget.
+        categories (list[Category]): A list of categories in the budget.
+        months (list[Month]): A list of months in the budget.
+        transactions (list[dict]): A list of transactions in the budget.
+        subtransactions (list[dict]): A list of subtransactions in the budget.
+        scheduled_transactions (list[dict]): A list of scheduled transactions in the budget.
+        scheduled_subtransactions (list[dict]): A list of scheduled subtransactions in the budget.
+    """
+
     id: UUID
     name: str
-    last_modified_on: str
-    first_month: str
-    last_month: str
-    date_format: dict
-    currency_format: dict
-    accounts: list[dict]
+    last_modified_on: datetime
+    first_month: datetime
+    last_month: datetime
+    date_format: DateFormat
+    currency_format: CurrencyFormat
+    accounts: list[Account]
     payees: list[Payee]
     payee_locations: list[dict]
-    category_groups: list[dict]
-    categories: list[dict]
-    months: list[dict]
+    category_groups: list[CategoryGroup]
+    categories: list[Category]
+    months: list[Month]
     transactions: list[dict]
     subtransactions: list[dict]
     scheduled_transactions: list[dict]
@@ -26,31 +68,82 @@ class Budget(BaseModel):
 
 
 class ResponseDataBudget(BaseModel):
+    """
+    ResponseDataBudget is a model representing the response data for a budget.
+
+    Attributes:
+        budget (Budget): The budget data.
+        server_knowledge (int): The server knowledge value.
+    """
+
     budget: Budget
     server_knowledge: int
 
 
 class ResponseBudget(BaseModel):
+    """
+    ResponseBudget is a model representing the response structure for a budget.
+
+    Attributes:
+        data (ResponseDataBudget): The data attribute containing the budget details.
+    """
+
     data: ResponseDataBudget
 
 
 class ResponseDataBudgets(BaseModel):
+    """
+    ResponseDataBudgets is a model representing the response data for budgets.
+
+    Attributes:
+        budgets (list[Budget]): A list of Budget objects.
+        default_budget (Budget): The default Budget object.
+    """
+
     budgets: list[Budget]
     default_budget: Budget
 
 
 class ResponseBudgets(BaseModel):
+    """
+    ResponseBudgets is a model representing the response structure for budget-related data.
+
+    Attributes:
+        data (ResponseDataBudgets): The data attribute containing budget-related information.
+    """
+
     data: ResponseDataBudgets
 
 
 class BudgetSettings(BaseModel):
-    date_format: dict
-    currency_format: dict
+    """A class used to represent the settings for a budget.
+
+    Attributes:
+        date_format (dict): A dictionary representing the format for dates.
+        currency_format (dict): A dictionary representing the format for currency.
+    """
+
+    date_format: DateFormat
+    currency_format: CurrencyFormat
 
 
 class ResponseDataBudgetSettings(BaseModel):
+    """
+    ResponseDataBudgetSettings is a model representing the settings of a budget response.
+
+    Attributes:
+        settings (BudgetSettings): The settings of the budget.
+    """
+
     settings: BudgetSettings
 
 
 class ResponseBudgetSettings(BaseModel):
+    """
+    ResponseBudgetSettings is a model representing the settings of a budget response.
+
+    Attributes:
+        data (ResponseDataBudgetSettings): The data containing the budget settings.
+    """
+
     data: ResponseDataBudgetSettings

--- a/src/uynab/model/category.py
+++ b/src/uynab/model/category.py
@@ -1,0 +1,142 @@
+"""
+# Model category module.
+
+This module defines models for representing financial categories and category groups within a budgeting application.
+
+Classes:
+    Category: Represents a financial category with various attributes such as id, name, budgeted amount, and goal details.
+    ResponseDataCategory: Represents the response data for a single category.
+    ResponseCategory: Represents the response structure for a category.
+    CategoryGroup: Represents a group of categories with attributes such as id, name, and a list of categories.
+    ResponseDataCategoryGroup: Represents the response data for a category group, including server knowledge.
+    ResponseCategoryGroup: Represents the response structure for a category group.
+
+Each class uses Pydantic's BaseModel to enforce type validation and provide serialization/deserialization capabilities.
+"""
+
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class Category(BaseModel):
+    """
+    Represents a financial category within a budgeting application.
+
+    Attributes:
+        id (UUID): Unique identifier for the category.
+        category_group_id (UUID): Identifier for the group this category belongs to.
+        category_group_name (str): Name of the group this category belongs to.
+        name (str): Name of the category.
+        hidden (bool): Indicates if the category is hidden.
+        original_category_group_id (UUID): Original identifier for the group this category belongs to.
+        note (str): Additional notes about the category.
+        budgeted (int): Amount budgeted for this category.
+        activity (int): Amount of activity (transactions) in this category.
+        balance (int): Current balance of the category.
+        goal_type (str): Type of goal associated with the category. Default is "TB".
+        goal_needs_whole_amount (Optional[bool]): Indicates if the goal needs the whole amount.
+        goal_day (int): Day of the month associated with the goal.
+        goal_cadence (int): Cadence of the goal.
+        goal_cadence_frequency (int): Frequency of the goal cadence.
+        goal_creation_month (str): Month when the goal was created.
+        goal_target (int): Target amount for the goal.
+        goal_target_month (str): Target month for the goal.
+        goal_percentage_complete (int): Percentage of the goal that has been completed.
+        goal_months_to_budget (int): Number of months to budget for the goal.
+        goal_under_funded (int): Amount underfunded for the goal.
+        goal_overall_funded (int): Overall amount funded for the goal.
+        goal_overall_left (int): Overall amount left to fund for the goal.
+        deleted (bool): Indicates if the category has been deleted.
+    """
+
+    id: UUID
+    category_group_id: UUID
+    category_group_name: str
+    name: str
+    hidden: bool
+    original_category_group_id: UUID
+    note: str
+    budgeted: int
+    activity: int
+    balance: int
+    goal_type: str = "TB"
+    goal_needs_whole_amount: Optional[bool]
+    goal_day: int
+    goal_cadence: int
+    goal_cadence_frequency: int
+    goal_creation_month: str
+    goal_target: int
+    goal_target_month: str
+    goal_percentage_complete: int
+    goal_months_to_budget: int
+    goal_under_funded: int
+    goal_overall_funded: int
+    goal_overall_left: int
+    deleted: bool
+
+
+class ResponseDataCategory(BaseModel):
+    """
+    ResponseDataCategory is a model that represents the response data for a category.
+
+    Attributes:
+        category (Category): The category object associated with the response.
+    """
+
+    category: Category
+
+
+class ResponseCategory(BaseModel):
+    """
+    ResponseCategory is a model representing the response structure for a category.
+
+    Attributes:
+        data (ResponseDataCategory): The data attribute containing the category details.
+    """
+
+    data: ResponseDataCategory
+
+
+class CategoryGroup(BaseModel):
+    """
+    Represents a group of categories in the budgeting application.
+
+    Attributes:
+        id (UUID): The unique identifier of the category group.
+        name (str): The name of the category group.
+        hidden (bool): Indicates whether the category group is hidden.
+        deleted (bool): Indicates whether the category group is deleted.
+        categories (list[Category]): A list of categories that belong to this group.
+    """
+
+    id: UUID
+    name: str
+    hidden: bool
+    deleted: bool
+    categories: list[Category]
+
+
+class ResponseDataCategoryGroup(BaseModel):
+    """
+    ResponseDataCategoryGroup represents the response data for a category group.
+
+    Attributes:
+        category_groups (list[CategoryGroup]): A list of category groups.
+        server_knowledge (int): The server knowledge value.
+    """
+
+    category_groups: list[CategoryGroup]
+    server_knowledge: int
+
+
+class ResponseCategoryGroup(BaseModel):
+    """
+    ResponseCategoryGroup represents a category group in the response model.
+
+    Attributes:
+        data (ResponseDataCategoryGroup): The data associated with the category group.
+    """
+
+    data: ResponseDataCategoryGroup

--- a/src/uynab/model/payee.py
+++ b/src/uynab/model/payee.py
@@ -34,6 +34,7 @@ Example Usage:
     ```
 """
 
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -52,7 +53,7 @@ class Payee(BaseModel):
 
     id: UUID
     name: str
-    transfer_account_id: UUID | None
+    transfer_account_id: Optional[UUID]
     deleted: bool
 
 

--- a/src/uynab/model/utils.py
+++ b/src/uynab/model/utils.py
@@ -1,0 +1,114 @@
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from .category import Category
+
+
+class Account(BaseModel):
+    """
+    Account model representing a financial account.
+
+    Attributes:
+        id (UUID): Unique identifier for the account.
+        name (str): Name of the account.
+        type (str): Type of the account (e.g., checking, savings).
+        on_budget (bool): Indicates if the account is on budget.
+        closed (bool): Indicates if the account is closed.
+        note (Optional[str]): Additional notes about the account.
+        balance (int): Current balance of the account.
+        cleared_balance (int): Cleared balance of the account.
+        uncleared_balance (int): Uncleared balance of the account.
+        transfer_payee_id (UUID): Identifier for the transfer payee.
+        direct_import_linked (bool): Indicates if the account is linked for direct import.
+        direct_import_in_error (bool): Indicates if there is an error with direct import.
+        last_reconciled_at (Optional[str]): Timestamp of the last reconciliation.
+        debt_original_balance (Optional[int]): Original balance of the debt.
+        debt_interest_rates (dict[datetime, int]): Interest rates of the debt over time.
+        debt_minimum_payments (dict[datetime, int]): Minimum payments of the debt over time.
+        debt_escrow_amounts (dict[datetime, int]): Escrow amounts of the debt over time.
+        deleted (bool): Indicates if the account is deleted.
+    """
+
+    id: UUID
+    name: str
+    type: str
+    on_budget: bool
+    closed: bool
+    note: Optional[str]
+    balance: int
+    cleared_balance: int
+    uncleared_balance: int
+    transfer_payee_id: UUID
+    direct_import_linked: bool
+    direct_import_in_error: bool
+    last_reconciled_at: Optional[str]
+    debt_original_balance: Optional[int]
+    debt_interest_rates: dict[datetime, int]
+    debt_minimum_payments: dict[datetime, int]
+    debt_escrow_amounts: dict[datetime, int]
+    deleted: bool
+
+
+class DateFormat(BaseModel):
+    """A class used to represent a Date Format.
+
+    Attributes:
+        format (str): A string representing the date format.
+    """
+
+    format: str
+
+
+class CurrencyFormat(BaseModel):
+    """
+    CurrencyFormat is a model that represents the formatting details for a specific currency.
+
+    Attributes:
+        iso_code (str): The ISO 4217 code for the currency (e.g., 'USD' for US Dollar).
+        example_format (str): An example of how the currency is formatted (e.g., '$1,234.56').
+        decimal_digits (int): The number of decimal digits used in the currency (e.g., 2 for USD).
+        decimal_separator (str): The character used to separate the integer part from the fractional part (e.g., '.' for USD).
+        symbol_first (bool): Indicates whether the currency symbol appears before the amount (True) or after (False).
+        group_separator (str): The character used to separate groups of thousands (e.g., ',' for USD).
+        currency_symbol (str): The symbol used to represent the currency (e.g., '$' for USD).
+        display_symbol (bool): Indicates whether the currency symbol should be displayed (True) or not (False).
+    """
+
+    iso_code: str
+    example_format: str
+    decimal_digits: int
+    decimal_separator: str
+    symbol_first: bool
+    group_separator: str
+    currency_symbol: str
+    display_symbol: bool
+
+
+class Month(BaseModel):
+    """
+    Represents a financial month with various attributes.
+
+    Attributes:
+        month (datetime): The month this instance represents.
+        note (Optional[str]): An optional note for the month.
+        income (int): The total income for the month.
+        budgeted (int): The total amount budgeted for the month.
+        activity (int): The total financial activity for the month.
+        to_be_budgeted (int): The amount left to be budgeted for the month.
+        age_of_money (int): The age of money in days.
+        deleted (bool): Indicates if the month record is deleted.
+        categories (list[Category]): A list of categories associated with the month.
+    """
+
+    month: datetime
+    note: Optional[str]
+    income: int
+    budgeted: int
+    activity: int
+    to_be_budgeted: int
+    age_of_money: int
+    deleted: bool
+    categories: list[Category]

--- a/src/uynab/service/budget.py
+++ b/src/uynab/service/budget.py
@@ -1,3 +1,12 @@
+"""
+# Service budget module
+
+This module provides the BudgetService class for interacting with budget-related endpoints of the YNAB API.
+
+Classes:
+    BudgetService: A service class for retrieving and managing budgets and their settings.
+"""
+
 from uuid import UUID
 
 from uynab.model.budget import (

--- a/src/uynab/service/category.py
+++ b/src/uynab/service/category.py
@@ -1,13 +1,55 @@
+"""
+# Service category module.
+
+This module provides services for interacting with categories and category groups
+within a budget in the YNAB (You Need A Budget) application.
+
+Classes:
+    CategoryService: A service class for retrieving category groups and categories
+    from a specified budget.
+"""
+
+from uuid import UUID
+
+from uynab.model.category import (
+    Category,
+    CategoryGroup,
+    ResponseCategory,
+    ResponseCategoryGroup,
+)
 from uynab.service.service import YNABService
 
 
 class CategoryService(YNABService):
-    def get_all_categories(self, budget_id: str):
-        """Fetch all categories for the specic budget"""
-        return self.client.request("GET", f"budgets/{budget_id}/categories")
+    def get_all_categories(self, budget_id: UUID) -> list[CategoryGroup]:
+        """
+        Retrieve all category groups for a given budget.
+        Inside the gategory group there are categories.
 
-    def get_category(self, budget_id, category_id: str):
-        """Fetch a single budget by ID"""
-        return self.client.request(
-            "GET", f"budgets/{budget_id}/categories/{category_id}"
+        Args:
+            budget_id (UUID): The unique identifier of the budget.
+
+        Returns:
+            list[CategoryGroup]: A list of category groups associated with the budget.
+        """
+
+        response = self.perform_api_call(
+            ResponseCategoryGroup, "GET", f"budgets/{budget_id}/categories"
         )
+        return response.data.category_groups
+
+    def get_category(self, budget_id: UUID, category_id: UUID) -> Category:
+        """
+        Retrieve a specific category from a budget.
+
+        Args:
+            budget_id (UUID): The unique identifier of the budget.
+            category_id (UUID): The unique identifier of the category.
+
+        Returns:
+            Category: The category object retrieved from the budget.
+        """
+        response = self.perform_api_call(
+            ResponseCategory, "GET", f"budgets/{budget_id}/categories/{category_id}"
+        )
+        return response.data.category

--- a/src/uynab/service/service.py
+++ b/src/uynab/service/service.py
@@ -16,7 +16,7 @@ class YNABService:
         client (Client): The client used for communication with YNAB.
 
     Methods:
-        request(model: Model, method: str, endpoint: str, data: dict | None = None) -> dict:
+        perform_api_call(model: Model, method: str, endpoint: str, data: dict | None = None) -> dict:
             Sends a request to the specified endpoint using the given method and data.
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 import uuid
 from unittest.mock import MagicMock
+from uuid import UUID
 
 import pytest
 
 from uynab.client import YNABClient
+from uynab.model.category import Category, CategoryGroup
 from uynab.model.payee import Payee
 
 
@@ -33,3 +35,65 @@ def payee():
 @pytest.fixture
 def budget_id():
     return uuid.uuid4()
+
+
+@pytest.fixture
+def category_id():
+    return UUID("3fa85f64-5717-4562-b3fc-2c963f66afa6")
+
+
+@pytest.fixture
+def category_data(category_id):
+    return {
+        "id": category_id,
+        "category_group_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "category_group_name": "Test  Category Group",
+        "name": "Test Category",
+        "hidden": True,
+        "original_category_group_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "note": "string",
+        "budgeted": 0,
+        "activity": 0,
+        "balance": 0,
+        "goal_type": "TB",
+        "goal_needs_whole_amount": None,
+        "goal_day": 0,
+        "goal_cadence": 0,
+        "goal_cadence_frequency": 0,
+        "goal_creation_month": "2024-12-22",
+        "goal_target": 0,
+        "goal_target_month": "2024-12-22",
+        "goal_percentage_complete": 0,
+        "goal_months_to_budget": 0,
+        "goal_under_funded": 0,
+        "goal_overall_funded": 0,
+        "goal_overall_left": 0,
+        "deleted": True,
+    }
+
+
+@pytest.fixture
+def category(category_data):
+    return Category(**category_data)
+
+
+@pytest.fixture
+def category_group_id():
+    return UUID("3fa85f64-5717-4562-b3fc-2c963f66afa6")
+
+
+@pytest.fixture
+def category_group_data(category_group_id, category_data):
+    category = Category(**category_data)
+    return {
+        "id": category_group_id,
+        "name": "Test Category Group",
+        "hidden": True,
+        "deleted": True,
+        "categories": [category],
+    }
+
+
+@pytest.fixture
+def category_group(category_group_data):
+    return CategoryGroup(**category_group_data)

--- a/tests/test_model_budget.py
+++ b/tests/test_model_budget.py
@@ -16,10 +16,19 @@ def budget_data(budget_id):
         "id": budget_id,
         "name": "Test Budget",
         "last_modified_on": "2023-10-01",
-        "first_month": "2023-01",
-        "last_month": "2023-10",
-        "date_format": {"format": "MM/DD/YYYY"},
-        "currency_format": {"iso_code": "USD"},
+        "first_month": "2023-01-01",
+        "last_month": "2023-10-01",
+        "date_format": {"format": "YYYY-MM-DD"},
+        "currency_format": {
+            "iso_code": "PLN",
+            "example_format": "123 456,78",
+            "decimal_digits": 2,
+            "decimal_separator": ",",
+            "symbol_first": False,
+            "group_separator": " ",
+            "currency_symbol": " z\u0142",
+            "display_symbol": True,
+        },
         "accounts": [],
         "payees": [],
         "payee_locations": [],
@@ -57,21 +66,39 @@ def test_response_budget_creation(budget_data, budget_id):
 def test_budget_settings_creation():
     settings_data = {
         "date_format": {"format": "MM/DD/YYYY"},
-        "currency_format": {"iso_code": "USD"},
+        "currency_format": {
+            "iso_code": "PLN",
+            "example_format": "123 456,78",
+            "decimal_digits": 2,
+            "decimal_separator": ",",
+            "symbol_first": False,
+            "group_separator": " ",
+            "currency_symbol": " z\u0142",
+            "display_symbol": True,
+        },
     }
     budget_settings = BudgetSettings(**settings_data)
-    assert budget_settings.date_format["format"] == "MM/DD/YYYY"
-    assert budget_settings.currency_format["iso_code"] == "USD"
+    assert budget_settings.date_format.format == "MM/DD/YYYY"
+    assert budget_settings.currency_format.iso_code == "PLN"
 
 
 def test_response_budget_settings_creation():
     settings_data = {
         "date_format": {"format": "MM/DD/YYYY"},
-        "currency_format": {"iso_code": "USD"},
+        "currency_format": {
+            "iso_code": "PLN",
+            "example_format": "123 456,78",
+            "decimal_digits": 2,
+            "decimal_separator": ",",
+            "symbol_first": False,
+            "group_separator": " ",
+            "currency_symbol": " z\u0142",
+            "display_symbol": True,
+        },
     }
     budget_settings = BudgetSettings(**settings_data)
     response_data_budget_settings = ResponseDataBudgetSettings(settings=budget_settings)
     response_budget_settings = ResponseBudgetSettings(
         data=response_data_budget_settings
     )
-    assert response_budget_settings.data.settings.date_format["format"] == "MM/DD/YYYY"
+    assert response_budget_settings.data.settings.date_format.format == "MM/DD/YYYY"

--- a/tests/test_model_category.py
+++ b/tests/test_model_category.py
@@ -1,0 +1,62 @@
+import pytest
+from pydantic import ValidationError
+
+from uynab.model.category import (
+    Category,
+    CategoryGroup,
+    ResponseCategory,
+    ResponseCategoryGroup,
+    ResponseDataCategory,
+    ResponseDataCategoryGroup,
+)
+
+
+def test_category_creation(category_data, category_id):
+    category = Category(**category_data)
+    assert category.id == category_id
+    assert category.name == "Test Category"
+
+
+def test_category_invalid_uuid(category_data):
+    category_data["id"] = "invalid-uuid"
+    with pytest.raises(ValidationError):
+        Category(**category_data)
+
+
+def test_response_data_category(category_data):
+    category = Category(**category_data)
+    response_data_category = ResponseDataCategory(category=category)
+    assert response_data_category.category == category
+
+
+def test_response_category(category_data):
+    category = Category(**category_data)
+    response_data_category = ResponseDataCategory(category=category)
+    response_category = ResponseCategory(data=response_data_category)
+    assert response_category.data == response_data_category
+
+
+def test_category_group_creation(category_group_data, category_group_id):
+    category_group = CategoryGroup(**category_group_data)
+    assert category_group.id == category_group_id
+    assert category_group.name == "Test Category Group"
+    assert len(category_group.categories) == 1
+    assert category_group.categories[0].name == "Test Category"
+
+
+def test_response_data_category_group(category_group_data):
+    category_group = CategoryGroup(**category_group_data)
+    response_data_category_group = ResponseDataCategoryGroup(
+        category_groups=[category_group], server_knowledge=1
+    )
+    assert response_data_category_group.category_groups[0] == category_group
+    assert response_data_category_group.server_knowledge == 1
+
+
+def test_response_category_group(category_group_data):
+    category_group = CategoryGroup(**category_group_data)
+    response_data_category_group = ResponseDataCategoryGroup(
+        category_groups=[category_group], server_knowledge=1
+    )
+    response_category_group = ResponseCategoryGroup(data=response_data_category_group)
+    assert response_category_group.data == response_data_category_group

--- a/tests/test_service_budget.py
+++ b/tests/test_service_budget.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 import pytest
 
-from uynab.service.budget import BudgetService
+from uynab.service.budget import BudgetService, BudgetSettings
 
 
 @pytest.fixture
@@ -18,15 +18,15 @@ def mock_budget():
         "last_modified_on": "2024-12-16T19:53:48.861Z",
         "first_month": "2024-12-16",
         "last_month": "2024-12-16",
-        "date_format": {"format": "string"},
+        "date_format": {"format": "2024-12-16"},
         "currency_format": {
-            "iso_code": "string",
-            "example_format": "string",
-            "decimal_digits": 0,
-            "decimal_separator": "string",
-            "symbol_first": True,
-            "group_separator": "string",
-            "currency_symbol": "string",
+            "iso_code": "PLN",
+            "example_format": "123 456,78",
+            "decimal_digits": 2,
+            "decimal_separator": ",",
+            "symbol_first": False,
+            "group_separator": " ",
+            "currency_symbol": " z\u0142",
             "display_symbol": True,
         },
         "accounts": [
@@ -46,19 +46,19 @@ def mock_budget():
                 "last_reconciled_at": "2024-12-16T19:53:48.861Z",
                 "debt_original_balance": 0,
                 "debt_interest_rates": {
-                    "additionalProp1": 0,
-                    "additionalProp2": 0,
-                    "additionalProp3": 0,
+                    "2024-01-01": 0,
+                    "2024-01-02": 0,
+                    "2024-01-03": 0,
                 },
                 "debt_minimum_payments": {
-                    "additionalProp1": 0,
-                    "additionalProp2": 0,
-                    "additionalProp3": 0,
+                    "2024-01-04": 0,
+                    "2024-01-05": 0,
+                    "2024-01-06": 0,
                 },
                 "debt_escrow_amounts": {
-                    "additionalProp1": 0,
-                    "additionalProp2": 0,
-                    "additionalProp3": 0,
+                    "2024-01-07": 0,
+                    "2024-01-08": 0,
+                    "2024-01-09": 0,
                 },
                 "deleted": True,
             }
@@ -86,6 +86,34 @@ def mock_budget():
                 "name": "string",
                 "hidden": True,
                 "deleted": True,
+                "categories": [
+                    {
+                        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                        "category_group_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                        "category_group_name": "string",
+                        "name": "string",
+                        "hidden": True,
+                        "original_category_group_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                        "note": "string",
+                        "budgeted": 0,
+                        "activity": 0,
+                        "balance": 0,
+                        "goal_type": "TB",
+                        "goal_needs_whole_amount": None,
+                        "goal_day": 0,
+                        "goal_cadence": 0,
+                        "goal_cadence_frequency": 0,
+                        "goal_creation_month": "2024-12-16",
+                        "goal_target": 0,
+                        "goal_target_month": "2024-12-16",
+                        "goal_percentage_complete": 0,
+                        "goal_months_to_budget": 0,
+                        "goal_under_funded": 0,
+                        "goal_overall_funded": 0,
+                        "goal_overall_left": 0,
+                        "deleted": True,
+                    }
+                ],
             }
         ],
         "categories": [
@@ -229,15 +257,15 @@ def mock_budget():
 @pytest.fixture
 def budget_settings():
     return {
-        "date_format": {"format": "string"},
+        "date_format": {"format": "YYYY-MM-DD"},
         "currency_format": {
-            "iso_code": "string",
-            "example_format": "string",
-            "decimal_digits": 0,
-            "decimal_separator": "string",
-            "symbol_first": True,
-            "group_separator": "string",
-            "currency_symbol": "string",
+            "iso_code": "PLN",
+            "example_format": "123 456,78",
+            "decimal_digits": 2,
+            "decimal_separator": ",",
+            "symbol_first": False,
+            "group_separator": " ",
+            "currency_symbol": " z\u0142",
             "display_symbol": True,
         },
     }
@@ -283,7 +311,7 @@ def test_get_budget_settings(budget_service, mock_client, mock_budget, budget_se
 
     settings = budget_service.get_budget_settings(mock_budget["id"])
 
-    assert settings.currency_format == budget_settings["currency_format"]
+    assert settings.currency_format == BudgetSettings(**budget_settings).currency_format
 
 
 def test_get_budget_by_name(budget_service, mock_client, mock_budget):

--- a/tests/test_service_category.py
+++ b/tests/test_service_category.py
@@ -1,0 +1,43 @@
+from uuid import UUID
+
+import pytest
+
+from uynab.service.category import CategoryService
+
+
+@pytest.fixture
+def category_service(mock_client):
+    return CategoryService(mock_client)
+
+
+def test_get_all_categories(category_service, mock_client, category_group):
+    budget_id = UUID("12345678-1234-5678-1234-567812345678")
+
+    category_group_1 = category_group
+    category_group_1.id = UUID("87654321-4321-8765-4321-876543218765")
+    category_group_2 = category_group
+    category_group_2.id = UUID("12345678-1234-5678-1234-567812345678")
+
+    mock_response = [category_group_1, category_group_2]
+    mock_client.request.return_value = {
+        "data": {
+            "category_groups": mock_response,
+            "server_knowledge": 1,
+        }
+    }
+
+    categories = category_service.get_all_categories(budget_id)
+
+    assert len(categories) == 2
+    assert categories[0].id == category_group_1.id
+    assert categories[0].categories[0].id == category_group_1.categories[0].id
+
+
+def test_get_category(category_service, mock_client, category_data, category_id):
+    budget_id = UUID("12345678-1234-5678-1234-567812345678")
+
+    mock_client.request.return_value = {"data": {"category": category_data}}
+
+    category = category_service.get_category(budget_id, category_id)
+
+    assert category.id == category_id

--- a/tests/test_service_category.py
+++ b/tests/test_service_category.py
@@ -41,3 +41,37 @@ def test_get_category(category_service, mock_client, category_data, category_id)
     category = category_service.get_category(budget_id, category_id)
 
     assert category.id == category_id
+
+
+def test_get_all_categories_empty_groups(category_service, mock_client, category_group):
+    budget_id = UUID("12345678-1234-5678-1234-567812345678")
+    mock_client.request.return_value = {
+        "data": {
+            "category_groups": [
+                {
+                    "id": category_group.id,
+                    "name": "Empty Group",
+                    "hidden": False,
+                    "deleted": False,
+                    "categories": [],
+                }
+            ],
+            "server_knowledge": 1,
+        }
+    }
+
+    categories = category_service.get_all_categories(budget_id)
+    assert categories[0].categories == []
+
+
+def test_get_all_categories_group_with_no_categories(category_service, mock_client):
+    budget_id = UUID("12345678-1234-5678-1234-567812345678")
+    mock_client.request.return_value = {
+        "data": {
+            "category_groups": [],
+            "server_knowledge": 1,
+        }
+    }
+
+    categories = category_service.get_all_categories(budget_id)
+    assert categories == []


### PR DESCRIPTION
## Summary by Sourcery

Add models for categories and budgets, and implement the "get category" and "get all categories" endpoints.

New Features:
- Added a category endpoint that allows retrieval of all categories or a specific category by ID.

Tests:
- Added tests for the new category service and updated existing budget tests.