### PR TITLE
Fix typos

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -1,7 +1,7 @@
 # Custom Dictionary Words
-subtransactions
-subtransaction
 savesubtransaction
+subtransaction
+subtransactions
 uynab
-YNAB
 Walkiewicz
+YNAB

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,8 @@
     "superfences",
     "testpaths",
     "venv",
-    "excinfo"
+    "excinfo",
+    "stackoverflow"
   ],
   "cSpell.ignorePaths": [
         ".vscode",

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -35,7 +35,7 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
-5. Make sure your code lints (use [ruff]) formatter).
+5. Make sure your code lints (use [ruff] formatter).
 6. Issue that pull request!
 
 ## What do we need
@@ -56,7 +56,7 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 
 ## Same for any features
 
-Features or enhencements are welcome. Write an new [issue](https://github.com/ajwalkiewicz/uynab/issues) suggesting new feature or even better create your own pull request.
+Features or enhancements are welcome. Write an new [issue](https://github.com/ajwalkiewicz/uynab/issues) suggesting new feature or even better create your own pull request.
 
 ## Write bug reports with detail, background, and sample code
 
@@ -89,4 +89,4 @@ In cases where PEP's differ from `ruff`, always choose `ruff`!
 ## References
 
 This document was adapted from the open-source contribution guidelines for [Facebook's Draft](https://github.com/facebook/draft-js/blob/a9316a723f9e918afde44dea68b5f9f39b7d9b00/CONTRIBUTING.md),
-and modified acordingly for this porject needs.
+and modified accordingly for this project needs.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -84,6 +84,6 @@ By following these steps, you will have a development environment that is consis
 ## References
 
 * Python: https://www.python.org/ 
-* Project managment tool: [UV](https://docs.astral.sh/uv/)
+* Project management tool: [UV](https://docs.astral.sh/uv/)
 * Formatter: [Ruff](https://docs.astral.sh/ruff/)
 * Testing: [Pytest](https://docs.pytest.org/en/stable/index.html)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ pip install uynab
 
 To communicate with YNAB API, you need to instantiate a client and YNAB API token.
 
-Token can be passed as an parameter to `YNABClient`: `api_token="YOUR_YNAB_API_TOKEN"`
+Token can be passed as a parameter to `YNABClient`: `api_token="YOUR_YNAB_API_TOKEN"`
 
 ```python
 from uynab.client import YNABClient


### PR DESCRIPTION
## Summary by Sourcery

Fix typos and broken links in documentation.

Documentation:
- Fix typos in `contribution.md`, `environment.md`, and `getting-started.md`.
- Fix broken links in `environment.md` and `contribution.md`.